### PR TITLE
Fix cibuildwheel on musllinux

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -64,8 +64,7 @@ jobs:
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones via: "CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x"
           CIBW_ARCHS_LINUX: auto # currently, not support aarch64 ppc64le s390x because avx instruction is not supported on these platforms
           CIBW_BEFORE_ALL: >
-            apk add openblas-dev &&
-            apk add lapack-dev
+            apk add openblas-dev  lapack-dev jpeg-dev
       
       - name: Build wheels for manylinux
         if: runner.os == 'Linux'

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,7 +22,7 @@ jobs:
       run:
         working-directory: python
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build SDist
         run: |
@@ -46,23 +46,44 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: all
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+      
+      - name: Build wheels for musllinux
+        if: runner.os == 'Linux'
+        uses: pypa/cibuildwheel@v2.11.3
         with:
           package-dir: ./python ## trigger cibuildwheel in sub-directory
         env:
-          CIBW_SKIP: "pp* *-manylinux_aarch64 *-manylinux_ppc64le *-manylinux_s390x"
-          CIBW_TEST_SKIP: "*-musllinux_i686 *-musllinux_x86_64"  # lack of necessary libraries to compile dependencies
+          CIBW_BUILD: "cp*-musllinux_i686 cp*-musllinux_x86_64"
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones via: "CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x"
           CIBW_ARCHS_LINUX: auto # currently, not support aarch64 ppc64le s390x because avx instruction is not supported on these platforms
+          CIBW_BEFORE_ALL: >
+            apk add openblas-dev &&
+            apk add lapack-dev
+      
+      - name: Build wheels for manylinux
+        if: runner.os == 'Linux'
+        uses: pypa/cibuildwheel@v2.11.3
+        with:
+          package-dir: ./python ## trigger cibuildwheel in sub-directory
+        env:
+          CIBW_BUILD: "cp*-manylinux_i686 cp*-manylinux_x86_64"
+          # configure cibuildwheel to build native archs ('auto'), and some emulated ones via: "CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x"
+          CIBW_ARCHS_LINUX: auto # currently, not support aarch64 ppc64le s390x because avx instruction is not supported on these platforms
+      
+      - name: Build wheels for Windows/MacOS
+        if: runner.os != 'Linux'
+        uses: pypa/cibuildwheel@v2.11.3
+        with:
+          package-dir: ./python ## trigger cibuildwheel in sub-directory
+        env:
+          CIBW_SKIP: "pp*"
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2 # the latest MacOS support the Rosetta
 
       - name: Verify clean directory

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -53,7 +53,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
         with:
           platforms: all
-      
+
       - name: Build wheels for musllinux
         if: runner.os == 'Linux'
         uses: pypa/cibuildwheel@v2.11.3
@@ -64,8 +64,8 @@ jobs:
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones via: "CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x"
           CIBW_ARCHS_LINUX: auto # currently, not support aarch64 ppc64le s390x because avx instruction is not supported on these platforms
           CIBW_BEFORE_ALL: >
-            apk add openblas-dev  lapack-dev jpeg-dev
-      
+            apk add openblas-dev lapack-dev jpeg-dev
+
       - name: Build wheels for manylinux
         if: runner.os == 'Linux'
         uses: pypa/cibuildwheel@v2.11.3
@@ -75,7 +75,7 @@ jobs:
           CIBW_BUILD: "cp*-manylinux_i686 cp*-manylinux_x86_64"
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones via: "CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x"
           CIBW_ARCHS_LINUX: auto # currently, not support aarch64 ppc64le s390x because avx instruction is not supported on these platforms
-      
+
       - name: Build wheels for Windows/MacOS
         if: runner.os != 'Linux'
         uses: pypa/cibuildwheel@v2.11.3

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,4 @@ ignore:
   - "src"
   - "include"
   - "docs"
+  - "python/abess/functions.py"

--- a/python/pytest/test_check.py
+++ b/python/pytest/test_check.py
@@ -281,6 +281,22 @@ class TestCheck:
         else:
             assert False
 
+        try:
+            data = abess.make_glm_data(
+                n=100, p=10, k=3, family='gaussian', corr_type="null")
+        except ValueError as e:
+            print(e)
+        else:
+            assert False
+
+        try:
+            data = abess.make_multivariate_glm_data(
+                n=100, p=10, k=3, family='gaussian', corr_type="null")
+        except ValueError as e:
+            print(e)
+        else:
+            assert False
+
         # lack of necessary parameter
         try:
             model = abess.LinearRegression()

--- a/python/pytest/test_dataset.py
+++ b/python/pytest/test_dataset.py
@@ -21,7 +21,7 @@ class TestOther:
         rho = 0.
         sigma = 1.
 
-        for family in ['gaussian', 'binomial', 'poisson', 'gamma']:
+        for family in ['gaussian', 'binomial', 'poisson', 'gamma', 'ordinal']:
             data1 = abess.make_glm_data(
                 n=n,
                 p=p,
@@ -42,6 +42,14 @@ class TestOther:
                 sigma=sigma,
                 coef_=data1.coef_)
             assert (data1.coef_ == data2.coef_).all()
+            data3 = abess.make_glm_data(
+                n=n,
+                p=p,
+                k=k,
+                family=family,
+                rho=rho,
+                sigma=sigma,
+                corr_type="exp")
 
         for family in ['cox']:
             data1 = abess.make_glm_data(
@@ -84,6 +92,8 @@ class TestOther:
             data2 = abess.make_multivariate_glm_data(
                 n=n, p=p, k=k, family=family, rho=rho, M=M, coef_=data1.coef_)
             assert (data1.coef_ == data2.coef_).all()
+            data3 = abess.make_multivariate_glm_data(
+                n=n, p=p, k=k, family=family, rho=rho, M=M, corr_type="exp")
 
         data1 = abess.make_multivariate_glm_data(
             n=n, p=p, k=k, family='poisson', rho=rho, M=M)

--- a/python/pytest/test_dataset.py
+++ b/python/pytest/test_dataset.py
@@ -50,6 +50,7 @@ class TestOther:
                 rho=rho,
                 sigma=sigma,
                 corr_type="exp")
+            assert_shape(data3.x, data3.y, n, p, 1)
 
         for family in ['cox']:
             data1 = abess.make_glm_data(
@@ -72,6 +73,15 @@ class TestOther:
                 sigma=sigma,
                 coef_=data1.coef_)
             assert (data1.coef_ == data2.coef_).all()
+            data3 = abess.make_glm_data(
+                n=n,
+                p=p,
+                k=k,
+                family=family,
+                rho=rho,
+                sigma=sigma,
+                corr_type="exp")
+            assert_shape(data3.x, data3.y, n, p, 1)
 
     @staticmethod
     def test_multi_glm():
@@ -94,6 +104,7 @@ class TestOther:
             assert (data1.coef_ == data2.coef_).all()
             data3 = abess.make_multivariate_glm_data(
                 n=n, p=p, k=k, family=family, rho=rho, M=M, corr_type="exp")
+            assert_shape(data3.x, data3.y, n, p, M)
 
         data1 = abess.make_multivariate_glm_data(
             n=n, p=p, k=k, family='poisson', rho=rho, M=M)


### PR DESCRIPTION
Musllinux will fail on command `pip install pandas`, which is used for testing and the details can be checked in #462.

To fix it, I try to install the missing libraries [before compiling](https://cibuildwheel.readthedocs.io/en/stable/faq/#linux-builds-in-containers), including BLAS, LAPACK and JPEG. Now it works but will spend a tons of time on compiling the dependencies (about 1-2h) before testing.