### PR TITLE
Fix readthedoc build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ DoubleML
 pyts
 dowhy
 numpy<1.23
+Jinja2<3.1


### PR DESCRIPTION
Add `Jinja2<3.1` in the requirements. See readthedocs/readthedocs.org#9038 for further details.