### PR TITLE
Pin the version of some dependencies for readthedoc

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 Sphinx==4.5.0
-docutils==0.17.1
-sphinx-rtd-theme==1.1.1
+docutils<0.17
+sphinx-rtd-theme>=0.5.2
 sphinx-gallery
 sphinxcontrib-phpdomain
 sphinx-autoapi

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,6 @@
-Sphinx
+Sphinx==4.5.0
+docutils==0.17.1
+sphinx-rtd-theme==1.1.1
 sphinx-gallery
 sphinxcontrib-phpdomain
 sphinx-autoapi
@@ -7,4 +9,3 @@ DoubleML
 pyts
 dowhy
 numpy<1.23
-Jinja2<3.1

--- a/python/abess/linear.py
+++ b/python/abess/linear.py
@@ -15,10 +15,25 @@ except ImportError:
 def fix_docs(cls):
     # This function is to inherit the docstring from base class
     # and avoid unnecessary duplications on description.
-    index = cls.__doc__.find("Examples\n    --------\n")
-    if index != -1:
-        cls.__doc__ = cls.__doc__[:index] + \
-            cls.__bases__[0].__doc__ + cls.__doc__[index:]
+    title_index = cls.__doc__.find("Parameters\n    ----------")
+    more_para_index = cls.__doc__.find("Examples\n    --------")
+    base_para_index = cls.__bases__[0].__doc__.find(
+        "Attributes\n    ----------")
+    if title_index == -1:
+        title_index = 0
+    if more_para_index == -1:
+        more_para_index = len(cls.__doc__) - 1
+    # class title
+    full_doc = cls.__doc__[:title_index]
+    # class paras
+    full_doc = (full_doc +
+                cls.__bases__[0].__doc__[:base_para_index] +
+                cls.__doc__[title_index:more_para_index])
+    # more info
+    full_doc = (full_doc +
+                cls.__doc__[more_para_index:] +
+                cls.__bases__[0].__doc__[base_para_index:])
+    cls.__doc__ = full_doc
     return cls
 
 


### PR DESCRIPTION
From the building log, I find readthedoc use different version on some packages, e.g. Sphinx, compared to before.
It may cause the wrong format.

~~Now I pin some packages `Sphinx==4.5.0`, `docutils==0.17.1` and `sphinx-rtd-theme===1.1.1`, which were worked before.~~ This also fix #468, so I unpinned `Jinja2`.