### PR TITLE
Fix pypi workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           package-dir: ./python # trigger cibuildwheel in sub-directory
         env:
-          CIBW_BUILD: "*linux_i686 *linux_x86_64 *win* *macos*"
+          CIBW_BUILD: "*linux_i686 *linux_x86_64 *linux_aarch64 *win* *macos*"
           CIBW_SKIP: "pp*"
 
       - name: Verify clean directory

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -54,44 +54,13 @@ jobs:
         with:
           platforms: all
 
-      - name: Build wheels for musllinux
-        if: runner.os == 'Linux'
+      - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.3
         with:
           package-dir: ./python # trigger cibuildwheel in sub-directory
         env:
-          CIBW_BUILD: "cp*-musllinux_i686 cp*-musllinux_x86_64"
-          # CIBW_BEFORE_ALL: "apk add openblas-dev lapack-dev jpeg-dev"
-          CIBW_TEST_SKIP: "*" # some dependencies not provide wheel
-
-      - name: Build wheels for manylinux
-        if: runner.os == 'Linux'
-        uses: pypa/cibuildwheel@v2.11.3
-        with:
-          package-dir: ./python # trigger cibuildwheel in sub-directory
-        env:
-          CIBW_BUILD: "cp*-manylinux_i686 cp*-manylinux_x86_64"
-          CIBW_TEST_SKIP: "cp*-manylinux_i686" # test fail but no informative message return 
-
-      - name: Build wheels for Windows
-        if: runner.os == 'Windows'
-        uses: pypa/cibuildwheel@v2.11.3
-        with:
-          package-dir: ./python # trigger cibuildwheel in sub-directory
-        env:
-          CIBW_BUILD: "cp*"
-          CIBW_TEST_SKIP: "cp310-win32 cp311-win32" # some dependencies not provide wheel
-
-      - name: Build wheels for MacOS
-        if: runner.os == 'macos'
-        uses: pypa/cibuildwheel@v2.11.3
-        with:
-          package-dir: ./python # trigger cibuildwheel in sub-directory
-        env:
-          CIBW_BUILD: "cp*"
-          CIBW_ARCHS: "x86_64 arm64 universal2" # the latest MacOS support the Rosetta
-          CIBW_BEFORE_ALL: "brew install libomp" # install openmp library
-          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
+          CIBW_BUILD: "*linux_i686 *linux_x86_64 *win* *macos*"
+          CIBW_SKIP: "pp*"
 
       - name: Verify clean directory
         run: git diff --exit-code

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -58,32 +58,40 @@ jobs:
         if: runner.os == 'Linux'
         uses: pypa/cibuildwheel@v2.11.3
         with:
-          package-dir: ./python ## trigger cibuildwheel in sub-directory
+          package-dir: ./python # trigger cibuildwheel in sub-directory
         env:
           CIBW_BUILD: "cp*-musllinux_i686 cp*-musllinux_x86_64"
-          # configure cibuildwheel to build native archs ('auto'), and some emulated ones via: "CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x"
-          CIBW_ARCHS_LINUX: auto # currently, not support aarch64 ppc64le s390x because avx instruction is not supported on these platforms
-          CIBW_BEFORE_ALL: >
-            apk add openblas-dev lapack-dev jpeg-dev
+          # CIBW_BEFORE_ALL: "apk add openblas-dev lapack-dev jpeg-dev"
+          CIBW_TEST_SKIP: "*" # some dependencies not provide wheel
 
       - name: Build wheels for manylinux
         if: runner.os == 'Linux'
         uses: pypa/cibuildwheel@v2.11.3
         with:
-          package-dir: ./python ## trigger cibuildwheel in sub-directory
+          package-dir: ./python # trigger cibuildwheel in sub-directory
         env:
           CIBW_BUILD: "cp*-manylinux_i686 cp*-manylinux_x86_64"
-          # configure cibuildwheel to build native archs ('auto'), and some emulated ones via: "CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x"
-          CIBW_ARCHS_LINUX: auto # currently, not support aarch64 ppc64le s390x because avx instruction is not supported on these platforms
+          CIBW_TEST_SKIP: "cp*-manylinux_i686" # test fail but no informative message return 
 
-      - name: Build wheels for Windows/MacOS
-        if: runner.os != 'Linux'
+      - name: Build wheels for Windows
+        if: runner.os == 'Windows'
         uses: pypa/cibuildwheel@v2.11.3
         with:
-          package-dir: ./python ## trigger cibuildwheel in sub-directory
+          package-dir: ./python # trigger cibuildwheel in sub-directory
         env:
-          CIBW_SKIP: "pp*"
-          CIBW_ARCHS_MACOS: x86_64 arm64 universal2 # the latest MacOS support the Rosetta
+          CIBW_BUILD: "cp*"
+          CIBW_TEST_SKIP: "cp310-win32 cp311-win32" # some dependencies not provide wheel
+
+      - name: Build wheels for MacOS
+        if: runner.os == 'macos'
+        uses: pypa/cibuildwheel@v2.11.3
+        with:
+          package-dir: ./python # trigger cibuildwheel in sub-directory
+        env:
+          CIBW_BUILD: "cp*"
+          CIBW_ARCHS: "x86_64 arm64 universal2" # the latest MacOS support the Rosetta
+          CIBW_BEFORE_ALL: "brew install libomp" # install openmp library
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 
       - name: Verify clean directory
         run: git diff --exit-code

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -58,9 +58,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.3
         with:
           package-dir: ./python # trigger cibuildwheel in sub-directory
-        env:
-          CIBW_BUILD: "*linux_i686 *linux_x86_64 *linux_aarch64 *win* *macos*"
-          CIBW_SKIP: "pp*"
 
       - name: Verify clean directory
         run: git diff --exit-code

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies for windows
         if: matrix.os == 'windows-latest'
         run: |
-          choco install mingw git
+          choco install git
       - name: Install abess
         run: |
           python --version

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -31,18 +31,6 @@ jobs:
         uses: actions/setup-python@master
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies for ubuntu
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get install -y bash
-      - name: Install dependencies for macOS
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install bash
-      - name: Install dependencies for windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          choco install git
       - name: Install abess
         run: |
           python --version

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -16,12 +16,11 @@ build-backend = "setuptools.build_meta"
 # Configuration for cibuildwheel
 [tool.cibuildwheel]
 test-requires = "pytest"
-before-test = "pip install lifelines pandas"
 test-command = "pytest {package}"
-# skip cp310-win32 because scipy.whl file not exists in pypi: 
-# skip cp37-manylinux_i686 cp38-manylinux_i686 cp39-manylinux_i686 cp310-manylinux_i686 because tests fail but no informative message return 
-test-skip = "*-macosx_arm64 *-macosx_universal2:arm64 cp310-win32 cp37-manylinux_i686 cp38-manylinux_i686 cp39-manylinux_i686 cp310-manylinux_i686"
-
-# Install openmp library
-[tool.cibuildwheel.macos]
-before-all = "brew install libomp"
+before-test = """\
+    pip install lifelines pandas \
+    \"scipy<=1.9.1; python_version < '3.8' or sys.platform == 'win32'\" \
+    scipy \
+    \"scikit-learn<=0.24.2; python_version < '3.8' or sys.platform == 'win32'\" \
+    scikit-learn \
+    """

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "setuptools.build_meta"
 
 # Configuration for cibuildwheel
 [tool.cibuildwheel]
-build = "*linux_i686 *linux_x86_64 *linux_aarch64 *win* *macos*"
+build = "*linux_i686 *linux_x86_64 *win* *macos*"
 skip = "pp*"
 
 # skip test because lack of wheels for dependencies
@@ -30,9 +30,6 @@ before-test = "pip install lifelines pandas scipy scikit-learn"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]
-
-[tool.cibuildwheel.linux]
-archs = ["auto", "aarch64"]
 
 [[tool.cibuildwheel.overrides]]
 select = "*musllinux*"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,26 +15,28 @@ build-backend = "setuptools.build_meta"
 
 # Configuration for cibuildwheel
 [tool.cibuildwheel]
+build = "*linux_i686 *linux_x86_64 *linux_aarch64 *win* *macos*"
+skip = "pp*"
+archs-macos = ["x86_64", "arm64", "universal2"] # the latest MacOS support the Rosetta
+
+# skip test because lack of wheels for dependencies
+test-skip = """\
+    *manylinux_i686 \
+    *musllinux* \
+    cp310-win32 cp311-win32
+    """
 test-requires = "pytest"
 test-command = "pytest {package}"
 before-test = "pip install lifelines pandas scipy scikit-learn"
 
 [[tool.cibuildwheel.overrides]]
-select = "*manylinux*"
-test-skip = "*_i686" # some dependencies not provide wheel
-
-[[tool.cibuildwheel.overrides]]
 select = "*musllinux*"
 # before-all = "apk add openblas-dev lapack-dev jpeg-dev"
-test-skip = "*" # some dependencies not provide wheel
 
 [[tool.cibuildwheel.overrides]]
 select = "*win32"
 before-test = "pip install lifelines pandas \"scipy<=1.9.1\" \"scikit-learn<=0.24.2\""
-test-skip = "cp310-win32 cp311-win32" # some dependencies not provide wheel
 
 [[tool.cibuildwheel.overrides]]
 select = "*macos*"
-archs = ["x86_64", "arm64", "universal2"] # the latest MacOS support the Rosetta
 before-all = "brew install libomp" # install openmp library
-test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,8 +19,8 @@ test-requires = "pytest"
 test-command = "pytest {package}"
 before-test = """\
     pip install lifelines pandas \
-    \"scipy<=1.9.1; python_version < '3.8' or sys.platform == 'win32'\" \
+    \"scipy<=1.9.1; python_version < '3.8' and sys_platform == 'win32'\" \
     scipy \
-    \"scikit-learn<=0.24.2; python_version < '3.8' or sys.platform == 'win32'\" \
+    \"scikit-learn<=0.24.2; python_version < '3.8' and sys_platform == 'win32'\" \
     scikit-learn \
     """

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,12 +20,16 @@ test-command = "pytest {package}"
 before-test = "pip install lifelines pandas scipy scikit-learn"
 
 [[tool.cibuildwheel.overrides]]
-select = "*-musllinux*"
+select = "*manylinux*"
+test-skip = "*_i686" # some dependencies not provide wheel
+
+[[tool.cibuildwheel.overrides]]
+select = "*musllinux*"
 # before-all = "apk add openblas-dev lapack-dev jpeg-dev"
 test-skip = "*" # some dependencies not provide wheel
 
 [[tool.cibuildwheel.overrides]]
-select = "*-win32"
+select = "*win32"
 before-test = "pip install lifelines pandas \"scipy<=1.9.1\" \"scikit-learn<=0.24.2\""
 test-skip = "cp310-win32 cp311-win32" # some dependencies not provide wheel
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,6 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 build = "*linux_i686 *linux_x86_64 *linux_aarch64 *win* *macos*"
 skip = "pp*"
-archs-macos = ["x86_64", "arm64", "universal2"] # the latest MacOS support the Rosetta
 
 # skip test because lack of wheels for dependencies
 test-skip = """\
@@ -28,6 +27,12 @@ test-skip = """\
 test-requires = "pytest"
 test-command = "pytest {package}"
 before-test = "pip install lifelines pandas scipy scikit-learn"
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "universal2", "arm64"]
+
+[tool.cibuildwheel.linux]
+archs = ["auto", "aarch64"]
 
 [[tool.cibuildwheel.overrides]]
 select = "*musllinux*"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,10 +17,20 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 test-requires = "pytest"
 test-command = "pytest {package}"
-before-test = """\
-    pip install lifelines pandas \
-    \"scipy<=1.9.1; python_version < '3.8' and sys_platform == 'win32'\" \
-    scipy \
-    \"scikit-learn<=0.24.2; python_version < '3.8' and sys_platform == 'win32'\" \
-    scikit-learn \
-    """
+before-test = "pip install lifelines pandas scipy scikit-learn"
+
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux*"
+# before-all = "apk add openblas-dev lapack-dev jpeg-dev"
+test-skip = "*" # some dependencies not provide wheel
+
+[[tool.cibuildwheel.overrides]]
+select = "*-win32"
+before-test = "pip install lifelines pandas \"scipy<=1.9.1\" \"scikit-learn<=0.24.2\""
+test-skip = "cp310-win32 cp311-win32" # some dependencies not provide wheel
+
+[[tool.cibuildwheel.overrides]]
+select = "*macos*"
+archs = ["x86_64", "arm64", "universal2"] # the latest MacOS support the Rosetta
+before-all = "brew install libomp" # install openmp library
+test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"


### PR DESCRIPTION
- use `scipy<=1.9.1` and `scikit-learn<=0.24.2` for testing on 32bit Windows platform because the later version does not provide wheels
- skip test on `cp310-win32` and `cp311-win32` because most dependencies do not provide wheels
- skip test on musllinux because of too long compling time on dependencies
- move all cibuildwheel's config to `python/pyproject.toml` for legibility