### PR TITLE
test: change test in R

### DIFF
--- a/R-package/tests/testthat/test-spca.R
+++ b/R-package/tests/testthat/test-spca.R
@@ -95,9 +95,9 @@ test_that("abesspca (FPC and golden-section) works", {
   expect_equal(spca_fit[["var.all"]], pca_var)
 
   ## check identity:
-  spca_fit1 <- abesspca(USArrests, tune.path = "gsection")
+  spca_fit1 <- abesspca(USArrests, tune.path = "gsection", gs.range = c(1,3))
   spca_fit2 <- abesspca(cov(USArrests) * (nrow(USArrests) - 1) / nrow(USArrests),
-    type = "gram", tune.path = "gsection"
+    type = "gram", tune.path = "gsection", gs.range = c(1,3)
   )
   spca_fit1[["call"]] <- NULL
   spca_fit2[["call"]] <- NULL


### PR DESCRIPTION
Comparing these two results is not a good choice, because `spca_fit2` doesn't know the sample size so the `gsection` tune path will be different. 
```
spca_fit1 <- abesspca(USArrests, tune.path = "gsection"

spca_fit2 <- abesspca(cov(USArrests) * (nrow(USArrests) - 1) / nrow(USArrests),
  type = "gram", tune.path = "gsection"
)
```
Actually, the path of `spca_fit1` is "2,3,2,3,4" and the path of `spca_fit1` is "2,3,2". Thus, I add `gs_range = c(1,3)` to correct it.