### PR TITLE
fix: handle correctly A_init and always_select

### DIFF
--- a/R-package/tests/testthat/test-spca.R
+++ b/R-package/tests/testthat/test-spca.R
@@ -95,9 +95,9 @@ test_that("abesspca (FPC and golden-section) works", {
   expect_equal(spca_fit[["var.all"]], pca_var)
 
   ## check identity:
-  spca_fit1 <- abesspca(USArrests, tune.path = "gsection")
+  spca_fit1 <- abesspca(USArrests, tune.path = "gsection", gs.range = c(1,3))
   spca_fit2 <- abesspca(cov(USArrests) * (nrow(USArrests) - 1) / nrow(USArrests),
-    type = "gram", tune.path = "gsection"
+    type = "gram", tune.path = "gsection", gs.range = c(1,3)
   )
   spca_fit1[["call"]] <- NULL
   spca_fit2[["call"]] <- NULL

--- a/src/Algorithm.h
+++ b/src/Algorithm.h
@@ -568,13 +568,13 @@ class Algorithm {
             Eigen::VectorXi U = Eigen::VectorXi::LinSpaced(N, 0, N - 1);
             Eigen::VectorXi U_ind = Eigen::VectorXi::LinSpaced(beta_size, 0, beta_size - 1);
             this->sacrifice(X, X_A, y, beta, beta_A, coef0, A, I, weights, g_index, g_size, N, A_ind, bd, U, U_ind, 0);
+            // A_init
+            for (int i = 0; i < A.size(); i++) {
+                bd(A(i)) = DBL_MAX / 2;
+            }
             // alway_select
             for (int i = 0; i < this->always_select.size(); i++) {
                 bd(this->always_select(i)) = DBL_MAX;
-            }
-            // A_init
-            for (int i = 0; i < A.size(); i++) {
-                bd(A(i)) = DBL_MAX - 1;
             }
         }
 

--- a/src/AlgorithmPCA.h
+++ b/src/AlgorithmPCA.h
@@ -155,14 +155,14 @@ class abessRPCA : public Algorithm<Eigen::VectorXd, Eigen::VectorXd, double, T4>
             S.resize(N, 1);
 
             for (int i = 0; i < N; i++) bd(i) = abs(S(i, 0));
-
-            for (int i = 0; i < (this->always_select).size(); i++) {
-                bd(this->always_select(i)) = DBL_MAX;
-            }
-
+            
             // A_init
             for (int i = 0; i < A.size(); i++) {
-                bd(A(i)) = DBL_MAX - 1;
+                bd(A(i)) = DBL_MAX / 2;
+            }
+            // alway_select
+            for (int i = 0; i < (this->always_select).size(); i++) {
+                bd(this->always_select(i)) = DBL_MAX;
             }
 
             this->r = (int)this->lambda_level;


### PR DESCRIPTION
There are two bugs in `inital_screening()`:

1. It should deal with `A_init` before `alway_select`.
2. Actually, `DBL_MAX == DBL_MAX -1` is true. Thus, we should use `DBL_MAX / 2` instead.

```
// A_init
for (int i = 0; i < A.size(); i++) {
    bd(A(i)) = DBL_MAX / 2;
}
// alway_select
for (int i = 0; i < (this->always_select).size(); i++) {
    bd(this->always_select(i)) = DBL_MAX;
}
```