### PR TITLE
Revert cibuildwheel to v2.3.1

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -55,7 +55,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.3
+        uses: pypa/cibuildwheel@v2.3.1
         with:
           package-dir: ./python # trigger cibuildwheel in sub-directory
 
@@ -68,23 +68,23 @@ jobs:
         with:
           path: wheelhouse/*.whl
 
-  #   upload_TestPyPI:
-  #     name: Upload alpha version to TestPyPI
-  #     needs: [build_wheels, build_sdist]
-  #     runs-on: ubuntu-latest
+  # upload_TestPyPI:
+  #   name: Upload alpha version to TestPyPI
+  #   needs: [build_wheels, build_sdist]
+  #   runs-on: ubuntu-latest
 
-  #     steps:
-  #       - uses: actions/download-artifact@v3
-  #         with:
-  #           name: artifact
-  #           path: dist
+  #   steps:
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+  #         path: dist
 
-  #       - uses: pypa/gh-action-pypi-publish@release/v1
-  #         with:
-  #           user: __token__
-  #           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-  #           repository_url: https://test.pypi.org/legacy/
-  #           verbose: true
+  #     - uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         user: __token__
+  #         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+  #         repository_url: https://test.pypi.org/legacy/
+  #         verbose: true
 
   upload_PyPI:
     name: Upload to PyPI if release

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst
 include LICENSE
+include CMakeLists.txt
 recursive-include include *
 recursive-include src *
 recursive-include abess *

--- a/python/abess/__init__.py
+++ b/python/abess/__init__.py
@@ -5,7 +5,7 @@
 # @Site    :
 # @File    : __init__.py
 
-__version__ = "0.4.6"
+__version__ = "0.4.7rc1"
 __author__ = ("Jin Zhu, Kangkang Jiang, "
               "Junhao Huang, Yanhang Zhang, "
               "Yanhang Zhang, Shiyun Lin, "

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,7 +26,7 @@ test-skip = """\
     cp310-win32 cp311-win32
     """
 test-requires = "pytest"
-test-command = "pytest {package}"
+test-command = "pytest {package}/pytest -v"
 before-test = "pip install lifelines pandas scipy scikit-learn"
 
 # install pybind11 for cmake
@@ -35,8 +35,8 @@ before-build = "pip install pybind11[global]"
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]
 
-[[tool.cibuildwheel.overrides]]
-select = "*musllinux*"
+# [[tool.cibuildwheel.overrides]]
+# select = "*musllinux*"
 # before-all = "apk add openblas-dev lapack-dev jpeg-dev"
 
 [[tool.cibuildwheel.overrides]]


### PR DESCRIPTION
- Revert `cibuildwheel` to `v2.3.1` to avoid #496;
- Add `CMakeLists.txt` into `python/MANIFEST.in`;