### PR TITLE
Use `pandas<2.0.0` for pytest

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: 3.9
       - name: Install abess & dependencies
         run: |
-          pip install pandas
+          pip install "pandas<2.0.0"
           pip install lifelines
           pip install pybind11[global]
           # pip install codecov

--- a/docs/Tutorial/1-glm/plot_4_CoxRegression.py
+++ b/docs/Tutorial/1-glm/plot_4_CoxRegression.py
@@ -186,7 +186,7 @@ print(cindex)
 # negative status would affect the survival function for each patient.
 #
 surv_fns = model.predict_survival_function(train[:, 2:])
-time_points = np.quantile(train[:, 0], np.linspace(0, 0.6, 100))
+time_points = np.quantile(train[:, 0], np.linspace(0, 0.6, 100)).astype(float)
 legend_handles = []
 legend_labels = []
 _, ax = plt.subplots(figsize=(9, 6))

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,7 @@ test-skip = """\
     """
 test-requires = "pytest"
 test-command = "pytest {package}/pytest -v"
-before-test = "pip install lifelines pandas scipy scikit-learn"
+before-test = "pip install lifelines \"pandas<2.0.0\" scipy scikit-learn"
 
 # install pybind11 for cmake
 before-build = "pip install pybind11[global]"
@@ -41,7 +41,7 @@ archs = ["x86_64", "universal2", "arm64"]
 
 [[tool.cibuildwheel.overrides]]
 select = "*win32"
-before-test = "pip install lifelines pandas \"scipy<=1.9.1\" \"scikit-learn<=0.24.2\""
+before-test = "pip install lifelines \"pandas<2.0.0\" \"scipy<=1.9.1\" \"scikit-learn<=0.24.2\""
 
 [[tool.cibuildwheel.overrides]]
 select = "*macos*"


### PR DESCRIPTION
`lifelines` is not compatible with the latest `pandas==2.0.0`, and they are working on it.

We may temporarily use older version for testing first.